### PR TITLE
First qskos validator draft and remove ACER details

### DIFF
--- a/resources/validators/items/qskos.ttl
+++ b/resources/validators/items/qskos.ttl
@@ -28,12 +28,6 @@ qskos:
     schema:version "0.1.0" ;
 .
 
-<https://ror.org/012x2n652>
-    a schema:Organization ;
-    schema:name "Australian Council for Educational Research" ;
-    schema:url "https://www.acer.org/"^^xsd:anyURI ;
-.
-
 <https://kurrawong.ai>
     a schema:Organization ;
     schema:name "Kurrawong AI" ;


### PR DESCRIPTION
Fist draft qskos validator.

Removed organization details for Australian Council for Educational Research.